### PR TITLE
Ability to do 'accent insensitive' searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Options
 | beginsWith | boolean | We can choose to match the beginning of an item's text, or anywhere within. | `false` |
 | caseSensitive | boolean | Whether to ignore character casing. | `false` |
 | typeDelay | integer | The filtering process takes place on the keyUp event. If you have a large list of items to process, you might want to set a higher value (in milliseconds) to prevent the filtering to be able to occur so frequently. So in other words, it would kind of "wait" a bit while the user types. | `0` |
+| replaceAccents | boolean | When checking a possible match, accents specified in `accentsToFind` are replaced in the item's text (only for the current comparison, **without altering** the original item text) by their corresponding value found in `replaceWith`. As a consequence, the search becomes insensitive to accentuation (e.g. the term 'jose' will be a positive match both for 'jose' and for 'josé'). | `false` |
+| accentsToFind | string | Accents to be found and replaced (just for the comparison, without altering the page's content) in the item's text. | `àáäâãèéëêìíïîòóöôõùúüûç` |
+| replaceWith | string | Characters that will replace their corresponding accentuated character (i.e. the one that has the same position in the `accentsToFind` string) if the `replaceAccents` option is set to `true`. | `aaaaaeeeeiiiiooooouuuuc` |
 
 Highlighting matching text
 --------------------------

--- a/instafilta.js
+++ b/instafilta.js
@@ -18,6 +18,9 @@
             hideEmptySections: true,
             beginsWith: false,
             caseSensitive: false,
+            replaceAccents: false,
+            accentsToFind: 'àáäâãèéëêìíïîòóöôõùúüûç',
+            replaceWith: 'aaaaaeeeeiiiiooooouuuuc',
             typeDelay: 0
 
         }, options);
@@ -42,6 +45,7 @@
         var doFiltering = function(term) {
             
             term = settings.caseSensitive ? term : term.toLowerCase();
+            term = settings.replaceAccents ? replaceAccents(term) : term;
             
             if (lastTerm === term) { return false; }
             else { lastTerm = term; }
@@ -55,9 +59,13 @@
                 
                 var $item = $(this),
                     originalText = $item.text(),
-                    targetText = settings.caseSensitive ? originalText : originalText.toLowerCase(),
-                    matchedIndex = targetText.indexOf(term),
+                    targetText = originalText,
                     matchedText = null;
+
+                targetText = settings.caseSensitive ? originalText : originalText.toLowerCase();
+                targetText = settings.replaceAccents ? replaceAccents(targetText) : targetText;
+
+                var matchedIndex = targetText.indexOf(term);
 
                 if (!$item.data('originalText')) { 
                     $item.data('originalText', originalText); 
@@ -79,6 +87,14 @@
             settings.hideEmptySections && hideEmptySections();            
         };
         
+        var replaceAccents = function (term) {
+            
+            for (i = 0; i < settings.accentsToFind.length; i++) {
+                term = term.replace(new RegExp(settings.accentsToFind.charAt(i), 'g'), settings.replaceWith.charAt(i));
+            }
+
+            return term;
+        };
         
         var onKeyUp = function() {
             var $field = $(this);
@@ -89,7 +105,6 @@
                 doFiltering($field.val());
             }, settings.typeDelay); 
         };
-        
         
         return $(this).on('keyup', onKeyUp);
     };


### PR DESCRIPTION
Hey Andreas,

Great job with the instaFilta plugin! One requirement I had in a project I'm currently working on was to be able to do 'accent insensitive' searches (e.g. the search term 'jose' will match both 'jose' and 'josé'). Since the project was already using your plugin (and it works great!), I decided to fork the repo and extend it so it can also support this functionality. I made my best to respect the coding practices / style I have observed in this codebase. Do you think this feature will also be useful to other users? Maybe we can expand the `accentsToFind` and `replaceWith` options default values so they will also work nice for other languages? The default values I put are perfect for Portuguese and probably good for a couple other languages too.

Greetings from Brazil,

Alex.